### PR TITLE
Rustler count set to visible again after viewers are found

### DIFF
--- a/src/gg/destiny/app/ThumbnailAdapter.java
+++ b/src/gg/destiny/app/ThumbnailAdapter.java
@@ -79,9 +79,12 @@ public class ThumbnailAdapter extends ArrayAdapter<Metadata> {
             holder = (ThumbnailHolder)row.getTag();
         }
 
+        // If both lines with View.VISIBLE and View.GONE are commented out, Destiny's channel has a
+        // rustler count in the live section, but it bugs out occasionally with incorrect numbers
         Metadata metadata = metadatas.get(position);
         if (metadata.rustlers > 0){
             holder.viewers.setText(Integer.toString(metadata.rustlers));
+            holder.viewers.setVisibility(View.VISIBLE);
         }else{
             holder.viewers.setVisibility(View.GONE);
         }


### PR DESCRIPTION
Sets visibility of the rustler count to VISIBLE when rustlers are detected.
The code originally set the visibility of the rustler count to GONE when 0 rustlers were found, but it never reset the visibility when rustlers were detected so this meant that as the app ran, the view counts of more and more channels would disappear.